### PR TITLE
fix memory leak

### DIFF
--- a/wsr88d_m31.c
+++ b/wsr88d_m31.c
@@ -594,6 +594,7 @@ Radar *wsr88d_load_m31_into_radar(Wsr88d_file *wf)
 	    n = read_wsr88d_ray_m31(wf, msg_size, &wsr88d_ray);
 	    if (n <= 0) {
                 RSL_free_radar(radar);
+                fprintf(stderr,"Error: could not read ray.\n")
                 return NULL;
             }
 	    raynum = wsr88d_ray.ray_hdr.azm_num;

--- a/wsr88d_m31.c
+++ b/wsr88d_m31.c
@@ -592,7 +592,10 @@ Radar *wsr88d_load_m31_into_radar(Wsr88d_file *wf)
 	    msg_size = (int) msghdr.msg_size * 2 - msg_hdr_size;
 
 	    n = read_wsr88d_ray_m31(wf, msg_size, &wsr88d_ray);
-	    if (n <= 0) return NULL;
+	    if (n <= 0) {
+                RSL_free_radar(radar);
+                return NULL;
+            }
 	    raynum = wsr88d_ray.ray_hdr.azm_num;
 	    if (raynum > MAXRAYS_M31) {
 		fprintf(stderr,"Error: raynum = %d, exceeds MAXRAYS_M31"


### PR DESCRIPTION
* on failed read_wsr88d_ray_m31(), radar object created isn't destroyed first.
* adding an informative error message when ray cannot be read